### PR TITLE
fix profile not showing after signup

### DIFF
--- a/app/views/users/_own_profile.html.erb
+++ b/app/views/users/_own_profile.html.erb
@@ -36,10 +36,12 @@
           <br><br>
           <span class="asset-download">
             <!-- Link to Asset -->
-              <% if @user.selections.last.campaign.live %>
-                <%= link_to 'DOWNLOAD', download_path%>
+              <% if @user.selections.empty? %>
+                  <p>You haven't joined any campaign yet!</p>
+              <% elsif @user.selections.last.campaign.live %>
+                  <%= link_to 'DOWNLOAD', download_path%>
               <% else %>
-                <p>Waiting for next live campaign...</p>
+                  <p>Waiting for your next live campaign...</p>
               <% end %>
           </span>
         </p>


### PR DESCRIPTION
This fixes the problem of the profile not showing after sign up (without having joined any campaign).